### PR TITLE
Display error fields in sentry better 

### DIFF
--- a/error.go
+++ b/error.go
@@ -31,7 +31,7 @@ func (err *errorWrapper) ToFields() Fields {
 	}
 
 	if err.InnerError != nil {
-		fields["innerError"] = errorToField(err.InnerError)
+		fields["innerError"] = errorToFields(err.InnerError)
 	}
 
 	if frame := err.Frame; frame != nil {

--- a/logger.go
+++ b/logger.go
@@ -57,18 +57,18 @@ func Warn(message string, data Fields) {
 
 // WarnError logs an error & fields at the Warn Level
 func WarnError(err error) {
-	log.WithField("error", errorToField(err)).Warn(err.Error())
+	log.WithFields(errorToFields(err)).Warn(err.Error())
 }
 
 // Error logs an error with the error message & converts the message to fields if Fielder is implemented
 func Error(err error) {
-	log.WithField("error", errorToField(err)).Error(err.Error())
+	log.WithFields(errorToFields(err)).Error(err.Error())
 }
 
 // Fatal logs errors in the same way as Error then flushes the errors and calls os.Exit(1)
 func Fatal(err error) {
 	// this doesn't use log.Fatal because we need to flush the hook before exiting
-	log.WithField("error", errorToField(err)).Error(err.Error())
+	log.WithFields(errorToFields(err)).Error(err.Error())
 	Flush()
 	os.Exit(1)
 }
@@ -80,14 +80,17 @@ func Flush() {
 	}
 }
 
-func errorToField(err error) interface{} {
+func errorToFields(err error) logrus.Fields {
 	if err == nil {
 		return nil
 	}
 
 	if fielder, ok := err.(Fielder); ok {
-		return fielder.ToFields()
+		return logrus.Fields(fielder.ToFields())
 	}
 
-	return err.Error()
+	return logrus.Fields{
+		"error": err.Error(),
+		"data": err,
+	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,8 @@
 package logger
 
 import (
+	"fmt"
+	"github.com/getsentry/raven-go"
 	"os"
 
 	logtry "github.com/evalphobia/logrus_sentry"
@@ -47,7 +49,23 @@ func init() {
 }
 
 func SetGlobalFields(data Fields) {
-	globalFields = logrus.Fields(data)
+	var tags raven.Tags
+
+	for key, value := range data {
+		var stringValue string
+		if str, ok := value.(string); ok {
+			stringValue = str
+		} else {
+			stringValue = fmt.Sprintf("%#v", value)
+		}
+
+		tags = append(tags, raven.Tag{
+			Key:   key,
+			Value: stringValue,
+		})
+	}
+
+	globalFields = logrus.Fields{"tags":tags}
 }
 
 // Info logs with the given message & addition fields at the INFO Level


### PR DESCRIPTION
Don't log the error as a single blob if we have rich fields, also add global fields that get logged as tags in sentry

Before: 

![image](https://user-images.githubusercontent.com/1028340/93786031-b8f14d80-fc26-11ea-8374-26d5a0bd15eb.png)

After:

![image](https://user-images.githubusercontent.com/1028340/93786146-dcb49380-fc26-11ea-94c4-bd08771ef96c.png)

![image](https://user-images.githubusercontent.com/1028340/93786445-3d43d080-fc27-11ea-8ecc-b13e6114a089.png)
