### PR TITLE
Add context fields at top level

### DIFF
--- a/error.go
+++ b/error.go
@@ -26,10 +26,6 @@ var _ Fielder = (*errorWrapper)(nil)
 func (err *errorWrapper) ToFields() Fields {
 	fields := Fields{"message": err.Message}
 
-	if err.Context != nil {
-		fields["context"] = err.Context
-	}
-
 	if err.InnerError != nil {
 		fields["innerError"] = errorToFields(err.InnerError)
 	}
@@ -40,6 +36,12 @@ func (err *errorWrapper) ToFields() Fields {
 		}
 		fields["file"] = frame.File
 		fields["line"] = frame.Line
+	}
+
+	if err.Context != nil {
+		for k, v := range err.Context {
+			fields[k] = v
+		}
 	}
 
 	return fields


### PR DESCRIPTION
Move custom fields to the top level instead of nested inside "context", this allows the special `http_request` and `user_name` fields to operate as expected

Before:

![image](https://user-images.githubusercontent.com/1028340/93982601-50ff4c00-fd79-11ea-93f8-42f9df91bbf0.png)

After:

![image](https://user-images.githubusercontent.com/1028340/93982632-5b214a80-fd79-11ea-82df-ec091b6b21c6.png)

![image](https://user-images.githubusercontent.com/1028340/93982696-73916500-fd79-11ea-97e7-3b12eeb4ed7d.png)
